### PR TITLE
Add proxy support

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,6 +105,6 @@ func (c *Client) TokenIsAuthorized(username, password, token, client_id string, 
 
 func (c *Client) httpClient(insecureSkipVerify bool) *http.Client {
 	config := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
-	tr := &http.Transport{TLSClientConfig: config}
+	tr := &http.Transport{TLSClientConfig: config, Proxy: http.ProxyFromEnvironment}
 	return &http.Client{Transport: tr}
 }


### PR DESCRIPTION
Currently the http client used does not take into consideration the proxy settings and it will not work in a proxied environment. 

This pull request adds the functionality to use the proxy environment variables if set.